### PR TITLE
Added 2012 US Senate data

### DIFF
--- a/2012/20121106__oh__general__senate.csv
+++ b/2012/20121106__oh__general__senate.csv
@@ -1,4 +1,4 @@
-county,candidate,party,office,discrict,votes
+county,candidate,party,office,district,votes
 Adams,Sherrod Brown,Democratic,U.S. Senate,,3924
 Adams,Josh Mandel,Republican,U.S. Senate,,6410
 Adams,Scott Rupert ,Independent ,U.S. Senate,,609

--- a/2012/20121106__oh__general__senate.csv
+++ b/2012/20121106__oh__general__senate.csv
@@ -1,0 +1,265 @@
+county,candidate,party,office,discrict,votes
+Adams,Sherrod Brown,Democratic,U.S. Senate,,3924
+Adams,Josh Mandel,Republican,U.S. Senate,,6410
+Adams,Scott Rupert ,Independent ,U.S. Senate,,609
+Allen,Sherrod Brown,Democratic,U.S. Senate,,17456
+Allen,Josh Mandel,Republican,U.S. Senate,,28817
+Allen,Scott Rupert ,Independent ,U.S. Senate,,1535
+Ashland,Sherrod Brown,Democratic,U.S. Senate,,8006
+Ashland,Josh Mandel,Republican,U.S. Senate,,14260
+Ashland,Scott Rupert ,Independent ,U.S. Senate,,1593
+Ashtabula,Sherrod Brown,Democratic,U.S. Senate,,21973
+Ashtabula,Josh Mandel,Republican,U.S. Senate,,17780
+Ashtabula,Scott Rupert ,Independent ,U.S. Senate,,2848
+Athens,Sherrod Brown,Democratic,U.S. Senate,,17662
+Athens,Josh Mandel,Republican,U.S. Senate,,8066
+Athens,Scott Rupert ,Independent ,U.S. Senate,,1200
+Auglaize,Sherrod Brown,Democratic,U.S. Senate,,5417
+Auglaize,Josh Mandel,Republican,U.S. Senate,,16481
+Auglaize,Scott Rupert ,Independent ,U.S. Senate,,942
+Belmont,Sherrod Brown,Democratic,U.S. Senate,,15021
+Belmont,Josh Mandel,Republican,U.S. Senate,,14370
+Belmont,Scott Rupert ,Independent ,U.S. Senate,,1385
+Brown,Sherrod Brown,Democratic,U.S. Senate,,6613
+Brown,Josh Mandel,Republican,U.S. Senate,,10473
+Brown,Scott Rupert ,Independent ,U.S. Senate,,994
+Butler,Sherrod Brown,Democratic,U.S. Senate,,61933
+Butler,Josh Mandel,Republican,U.S. Senate,,97228
+Butler,Scott Rupert ,Independent ,U.S. Senate,,7540
+Carroll,Sherrod Brown,Democratic,U.S. Senate,,5154
+Carroll,Josh Mandel,Republican,U.S. Senate,,6727
+Carroll,Scott Rupert ,Independent ,U.S. Senate,,1046
+Champaign,Sherrod Brown,Democratic,U.S. Senate,,6565
+Champaign,Josh Mandel,Republican,U.S. Senate,,10541
+Champaign,Scott Rupert ,Independent ,U.S. Senate,,1131
+Clark,Sherrod Brown,Democratic,U.S. Senate,,30599
+Clark,Josh Mandel,Republican,U.S. Senate,,30220
+Clark,Scott Rupert ,Independent ,U.S. Senate,,2951
+Clermont,Sherrod Brown,Democratic,U.S. Senate,,29834
+Clermont,Josh Mandel,Republican,U.S. Senate,,58220
+Clermont,Scott Rupert ,Independent ,U.S. Senate,,4820
+Clinton,Sherrod Brown,Democratic,U.S. Senate,,5730
+Clinton,Josh Mandel,Republican,U.S. Senate,,11211
+Clinton,Scott Rupert ,Independent ,U.S. Senate,,1007
+Columbiana,Sherrod Brown,Democratic,U.S. Senate,,20382
+Columbiana,Josh Mandel,Republican,U.S. Senate,,21884
+Columbiana,Scott Rupert ,Independent ,U.S. Senate,,3201
+Coshocton,Sherrod Brown,Democratic,U.S. Senate,,6457
+Coshocton,Josh Mandel,Republican,U.S. Senate,,8037
+Coshocton,Scott Rupert ,Independent ,U.S. Senate,,1088
+Crawford,Sherrod Brown,Democratic,U.S. Senate,,7197
+Crawford,Josh Mandel,Republican,U.S. Senate,,11168
+Crawford,Scott Rupert ,Independent ,U.S. Senate,,1206
+Cuyahoga,Sherrod Brown,Democratic,U.S. Senate,,427597
+Cuyahoga,Josh Mandel,Republican,U.S. Senate,,167263
+Cuyahoga,Scott Rupert ,Independent ,U.S. Senate,,20614
+Darke,Sherrod Brown,Democratic,U.S. Senate,,6649
+Darke,Josh Mandel,Republican,U.S. Senate,,17204
+Darke,Scott Rupert ,Independent ,U.S. Senate,,1261
+Defiance,Sherrod Brown,Democratic,U.S. Senate,,7314
+Defiance,Josh Mandel,Republican,U.S. Senate,,9566
+Defiance,Scott Rupert ,Independent ,U.S. Senate,,1047
+Delaware,Sherrod Brown,Democratic,U.S. Senate,,37374
+Delaware,Josh Mandel,Republican,U.S. Senate,,55260
+Delaware,Scott Rupert ,Independent ,U.S. Senate,,4001
+Erie,Sherrod Brown,Democratic,U.S. Senate,,21035
+Erie,Josh Mandel,Republican,U.S. Senate,,15653
+Erie,Scott Rupert ,Independent ,U.S. Senate,,2186
+Fairfield,Sherrod Brown,Democratic,U.S. Senate,,29111
+Fairfield,Josh Mandel,Republican,U.S. Senate,,38185
+Fairfield,Scott Rupert ,Independent ,U.S. Senate,,3691
+Fayette,Sherrod Brown,Democratic,U.S. Senate,,4000
+Fayette,Josh Mandel,Republican,U.S. Senate,,6121
+Fayette,Scott Rupert ,Independent ,U.S. Senate,,537
+Franklin,Sherrod Brown,Democratic,U.S. Senate,,339260
+Franklin,Josh Mandel,Republican,U.S. Senate,,199293
+Franklin,Scott Rupert ,Independent ,U.S. Senate,,22041
+Fulton,Sherrod Brown,Democratic,U.S. Senate,,8534
+Fulton,Josh Mandel,Republican,U.S. Senate,,11269
+Fulton,Scott Rupert ,Independent ,U.S. Senate,,1117
+Gallia,Sherrod Brown,Democratic,U.S. Senate,,5060
+Gallia,Josh Mandel,Republican,U.S. Senate,,6760
+Gallia,Scott Rupert ,Independent ,U.S. Senate,,507
+Geauga,Sherrod Brown,Democratic,U.S. Senate,,20264
+Geauga,Josh Mandel,Republican,U.S. Senate,,27533
+Geauga,Scott Rupert ,Independent ,U.S. Senate,,2255
+Greene,Sherrod Brown,Democratic,U.S. Senate,,32243
+Greene,Josh Mandel,Republican,U.S. Senate,,46979
+Greene,Scott Rupert ,Independent ,U.S. Senate,,3142
+Guernsey,Sherrod Brown,Democratic,U.S. Senate,,6868
+Guernsey,Josh Mandel,Republican,U.S. Senate,,8477
+Guernsey,Scott Rupert ,Independent ,U.S. Senate,,971
+Hamilton,Sherrod Brown,Democratic,U.S. Senate,,219299
+Hamilton,Josh Mandel,Republican,U.S. Senate,,176058
+Hamilton,Scott Rupert ,Independent ,U.S. Senate,,14388
+Hancock,Sherrod Brown,Democratic,U.S. Senate,,11894
+Hancock,Josh Mandel,Republican,U.S. Senate,,21520
+Hancock,Scott Rupert ,Independent ,U.S. Senate,,1773
+Hardin,Sherrod Brown,Democratic,U.S. Senate,,4416
+Hardin,Josh Mandel,Republican,U.S. Senate,,7131
+Hardin,Scott Rupert ,Independent ,U.S. Senate,,717
+Harrison,Sherrod Brown,Democratic,U.S. Senate,,3176
+Harrison,Josh Mandel,Republican,U.S. Senate,,3498
+Harrison,Scott Rupert ,Independent ,U.S. Senate,,389
+Henry,Sherrod Brown,Democratic,U.S. Senate,,5448
+Henry,Josh Mandel,Republican,U.S. Senate,,7738
+Henry,Scott Rupert ,Independent ,U.S. Senate,,829
+Highland,Sherrod Brown,Democratic,U.S. Senate,,5982
+Highland,Josh Mandel,Republican,U.S. Senate,,10683
+Highland,Scott Rupert ,Independent ,U.S. Senate,,964
+Hocking,Sherrod Brown,Democratic,U.S. Senate,,5717
+Hocking,Josh Mandel,Republican,U.S. Senate,,6057
+Hocking,Scott Rupert ,Independent ,U.S. Senate,,802
+Holmes,Sherrod Brown,Democratic,U.S. Senate,,2506
+Holmes,Josh Mandel,Republican,U.S. Senate,,8252
+Holmes,Scott Rupert ,Independent ,U.S. Senate,,633
+Huron,Sherrod Brown,Democratic,U.S. Senate,,10083
+Huron,Josh Mandel,Republican,U.S. Senate,,12443
+Huron,Scott Rupert ,Independent ,U.S. Senate,,1751
+Jackson,Sherrod Brown,Democratic,U.S. Senate,,5258
+Jackson,Josh Mandel,Republican,U.S. Senate,,7268
+Jackson,Scott Rupert ,Independent ,U.S. Senate,,658
+Jefferson,Sherrod Brown,Democratic,U.S. Senate,,16031
+Jefferson,Josh Mandel,Republican,U.S. Senate,,14786
+Jefferson,Scott Rupert ,Independent ,U.S. Senate,,1496
+Knox,Sherrod Brown,Democratic,U.S. Senate,,10186
+Knox,Josh Mandel,Republican,U.S. Senate,,16237
+Knox,Scott Rupert ,Independent ,U.S. Senate,,1562
+Lake,Sherrod Brown,Democratic,U.S. Senate,,54981
+Lake,Josh Mandel,Republican,U.S. Senate,,52795
+Lake,Scott Rupert ,Independent ,U.S. Senate,,6128
+Lawrence,Sherrod Brown,Democratic,U.S. Senate,,11085
+Lawrence,Josh Mandel,Republican,U.S. Senate,,12407
+Lawrence,Scott Rupert ,Independent ,U.S. Senate,,1076
+Licking,Sherrod Brown,Democratic,U.S. Senate,,33097
+Licking,Josh Mandel,Republican,U.S. Senate,,42691
+Licking,Scott Rupert ,Independent ,U.S. Senate,,4445
+Logan,Sherrod Brown,Democratic,U.S. Senate,,6479
+Logan,Josh Mandel,Republican,U.S. Senate,,13303
+Logan,Scott Rupert ,Independent ,U.S. Senate,,1240
+Lorain,Sherrod Brown,Democratic,U.S. Senate,,80854
+Lorain,Josh Mandel,Republican,U.S. Senate,,53332
+Lorain,Scott Rupert ,Independent ,U.S. Senate,,6415
+Lucas,Sherrod Brown,Democratic,U.S. Senate,,131887
+Lucas,Josh Mandel,Republican,U.S. Senate,,65067
+Lucas,Scott Rupert ,Independent ,U.S. Senate,,8452
+Madison,Sherrod Brown,Democratic,U.S. Senate,,6518
+Madison,Josh Mandel,Republican,U.S. Senate,,9379
+Madison,Scott Rupert ,Independent ,U.S. Senate,,1005
+Mahoning,Sherrod Brown,Democratic,U.S. Senate,,76182
+Mahoning,Josh Mandel,Republican,U.S. Senate,,33480
+Mahoning,Scott Rupert ,Independent ,U.S. Senate,,5104
+Marion,Sherrod Brown,Democratic,U.S. Senate,,11376
+Marion,Josh Mandel,Republican,U.S. Senate,,13656
+Marion,Scott Rupert ,Independent ,U.S. Senate,,1985
+Medina,Sherrod Brown,Democratic,U.S. Senate,,39008
+Medina,Josh Mandel,Republican,U.S. Senate,,45176
+Medina,Scott Rupert ,Independent ,U.S. Senate,,4562
+Meigs,Sherrod Brown,Democratic,U.S. Senate,,4132
+Meigs,Josh Mandel,Republican,U.S. Senate,,5175
+Meigs,Scott Rupert ,Independent ,U.S. Senate,,584
+Mercer,Sherrod Brown,Democratic,U.S. Senate,,4736
+Mercer,Josh Mandel,Republican,U.S. Senate,,15743
+Mercer,Scott Rupert ,Independent ,U.S. Senate,,849
+Miami,Sherrod Brown,Democratic,U.S. Senate,,15968
+Miami,Josh Mandel,Republican,U.S. Senate,,32866
+Miami,Scott Rupert ,Independent ,U.S. Senate,,2156
+Monroe,Sherrod Brown,Democratic,U.S. Senate,,3274
+Monroe,Josh Mandel,Republican,U.S. Senate,,3114
+Monroe,Scott Rupert ,Independent ,U.S. Senate,,292
+Montgomery,Sherrod Brown,Democratic,U.S. Senate,,135210
+Montgomery,Josh Mandel,Republican,U.S. Senate,,116345
+Montgomery,Scott Rupert ,Independent ,U.S. Senate,,9615
+Morgan,Sherrod Brown,Democratic,U.S. Senate,,2625
+Morgan,Josh Mandel,Republican,U.S. Senate,,3065
+Morgan,Scott Rupert ,Independent ,U.S. Senate,,337
+Morrow,Sherrod Brown,Democratic,U.S. Senate,,5511
+Morrow,Josh Mandel,Republican,U.S. Senate,,9414
+Morrow,Scott Rupert ,Independent ,U.S. Senate,,1111
+Muskingum,Sherrod Brown,Democratic,U.S. Senate,,15592
+Muskingum,Josh Mandel,Republican,U.S. Senate,,18748
+Muskingum,Scott Rupert ,Independent ,U.S. Senate,,2257
+Noble,Sherrod Brown,Democratic,U.S. Senate,,2127
+Noble,Josh Mandel,Republican,U.S. Senate,,3311
+Noble,Scott Rupert ,Independent ,U.S. Senate,,362
+Ottawa,Sherrod Brown,Democratic,U.S. Senate,,11291
+Ottawa,Josh Mandel,Republican,U.S. Senate,,9872
+Ottawa,Scott Rupert ,Independent ,U.S. Senate,,1115
+Paulding,Sherrod Brown,Democratic,U.S. Senate,,3277
+Paulding,Josh Mandel,Republican,U.S. Senate,,5147
+Paulding,Scott Rupert ,Independent ,U.S. Senate,,528
+Perry,Sherrod Brown,Democratic,U.S. Senate,,6734
+Perry,Josh Mandel,Republican,U.S. Senate,,7240
+Perry,Scott Rupert ,Independent ,U.S. Senate,,897
+Pickaway,Sherrod Brown,Democratic,U.S. Senate,,9344
+Pickaway,Josh Mandel,Republican,U.S. Senate,,13177
+Pickaway,Scott Rupert ,Independent ,U.S. Senate,,1337
+Pike,Sherrod Brown,Democratic,U.S. Senate,,5751
+Pike,Josh Mandel,Republican,U.S. Senate,,5117
+Pike,Scott Rupert ,Independent ,U.S. Senate,,561
+Portage,Sherrod Brown,Democratic,U.S. Senate,,37144
+Portage,Josh Mandel,Republican,U.S. Senate,,32531
+Portage,Scott Rupert ,Independent ,U.S. Senate,,4506
+Preble,Sherrod Brown,Democratic,U.S. Senate,,6045
+Preble,Josh Mandel,Republican,U.S. Senate,,12820
+Preble,Scott Rupert ,Independent ,U.S. Senate,,1076
+Putnam,Sherrod Brown,Democratic,U.S. Senate,,4584
+Putnam,Josh Mandel,Republican,U.S. Senate,,12899
+Putnam,Scott Rupert ,Independent ,U.S. Senate,,722
+Richland,Sherrod Brown,Democratic,U.S. Senate,,23758
+Richland,Josh Mandel,Republican,U.S. Senate,,30696
+Richland,Scott Rupert ,Independent ,U.S. Senate,,2742
+Ross,Sherrod Brown,Democratic,U.S. Senate,,14147
+Ross,Josh Mandel,Republican,U.S. Senate,,14059
+Ross,Scott Rupert ,Independent ,U.S. Senate,,1629
+Sandusky,Sherrod Brown,Democratic,U.S. Senate,,13606
+Sandusky,Josh Mandel,Republican,U.S. Senate,,13280
+Sandusky,Scott Rupert ,Independent ,U.S. Senate,,1770
+Scioto,Sherrod Brown,Democratic,U.S. Senate,,15116
+Scioto,Josh Mandel,Republican,U.S. Senate,,12958
+Scioto,Scott Rupert ,Independent ,U.S. Senate,,1329
+Seneca,Sherrod Brown,Democratic,U.S. Senate,,10525
+Seneca,Josh Mandel,Republican,U.S. Senate,,12802
+Seneca,Scott Rupert ,Independent ,U.S. Senate,,1703
+Shelby,Sherrod Brown,Democratic,U.S. Senate,,6045
+Shelby,Josh Mandel,Republican,U.S. Senate,,16087
+Shelby,Scott Rupert ,Independent ,U.S. Senate,,1107
+Stark,Sherrod Brown,Democratic,U.S. Senate,,87493
+Stark,Josh Mandel,Republican,U.S. Senate,,78708
+Stark,Scott Rupert ,Independent ,U.S. Senate,,10926
+Summit,Sherrod Brown,Democratic,U.S. Senate,,151198
+Summit,Josh Mandel,Republican,U.S. Senate,,98442
+Summit,Scott Rupert ,Independent ,U.S. Senate,,12541
+Trumbull,Sherrod Brown,Democratic,U.S. Senate,,62386
+Trumbull,Josh Mandel,Republican,U.S. Senate,,32066
+Trumbull,Scott Rupert ,Independent ,U.S. Senate,,5195
+Tuscarawas,Sherrod Brown,Democratic,U.S. Senate,,17940
+Tuscarawas,Josh Mandel,Republican,U.S. Senate,,19946
+Tuscarawas,Scott Rupert ,Independent ,U.S. Senate,,2598
+Union,Sherrod Brown,Democratic,U.S. Senate,,8144
+Union,Josh Mandel,Republican,U.S. Senate,,15553
+Union,Scott Rupert ,Independent ,U.S. Senate,,1369
+Van Wert,Sherrod Brown,Democratic,U.S. Senate,,3630
+Van Wert,Josh Mandel,Republican,U.S. Senate,,9401
+Van Wert,Scott Rupert ,Independent ,U.S. Senate,,598
+Vinton,Sherrod Brown,Democratic,U.S. Senate,,2414
+Vinton,Josh Mandel,Republican,U.S. Senate,,2679
+Vinton,Scott Rupert ,Independent ,U.S. Senate,,304
+Warren,Sherrod Brown,Democratic,U.S. Senate,,33787
+Warren,Josh Mandel,Republican,U.S. Senate,,70755
+Warren,Scott Rupert ,Independent ,U.S. Senate,,4528
+Washington,Sherrod Brown,Democratic,U.S. Senate,,11464
+Washington,Josh Mandel,Republican,U.S. Senate,,15904
+Washington,Scott Rupert ,Independent ,U.S. Senate,,1438
+Wayne,Sherrod Brown,Democratic,U.S. Senate,,19072
+Wayne,Josh Mandel,Republican,U.S. Senate,,28138
+Wayne,Scott Rupert ,Independent ,U.S. Senate,,2906
+Williams,Sherrod Brown,Democratic,U.S. Senate,,6640
+Williams,Josh Mandel,Republican,U.S. Senate,,9294
+Williams,Scott Rupert ,Independent ,U.S. Senate,,1177
+Wood,Sherrod Brown,Democratic,U.S. Senate,,31633
+Wood,Josh Mandel,Republican,U.S. Senate,,27905
+Wood,Scott Rupert ,Independent ,U.S. Senate,,2985
+Wyandot,Sherrod Brown,Democratic,U.S. Senate,,3728
+Wyandot,Josh Mandel,Republican,U.S. Senate,,6074
+Wyandot,Scott Rupert ,Independent ,U.S. Senate,,627


### PR DESCRIPTION
This is US Senate race data from 2012.

Source data from [here](http://www.sos.state.oh.us/SOS/elections/Research/electResultsMain/2012Results.aspx).