### PR TITLE
Added 2012 ohio state senate general election data

### DIFF
--- a/2012/20121106__oh__general__state_senate.csv
+++ b/2012/20121106__oh__general__state_senate.csv
@@ -1,0 +1,135 @@
+county,candidate,party,office,district,votes
+Auglaize,Cliff Hite ,Republican ,Ohio Senate,1,7797
+Defiance,Cliff Hite ,Republican ,Ohio Senate,1,11435
+Fulton,Cliff Hite ,Republican ,Ohio Senate,1,4238
+Hancock,Cliff Hite ,Republican ,Ohio Senate,1,25588
+Hardin,Cliff Hite ,Republican ,Ohio Senate,1,8556
+Henry,Cliff Hite ,Republican ,Ohio Senate,1,9011
+Logan,Cliff Hite ,Republican ,Ohio Senate,1,2164
+Paulding,Cliff Hite ,Republican ,Ohio Senate,1,5643
+Putnam,Cliff Hite ,Republican ,Ohio Senate,1,12516
+Van Wert,Cliff Hite ,Republican ,Ohio Senate,1,8688
+Williams,Cliff Hite ,Republican ,Ohio Senate,1,11836
+Erie,Jeff Bretz,Democratic,Ohio Senate,2,18595
+Erie,Randy Gardner ,Republican ,Ohio Senate,2,17830
+Fulton,Jeff Bretz,Democratic,Ohio Senate,2,4309
+Fulton,Randy Gardner ,Republican ,Ohio Senate,2,8397
+Lucas,Jeff Bretz,Democratic,Ohio Senate,2,17826
+Lucas,Randy Gardner ,Republican ,Ohio Senate,2,27175
+Ottawa,Jeff Bretz,Democratic,Ohio Senate,2,9418
+Ottawa,Randy Gardner ,Republican ,Ohio Senate,2,11807
+Wood,Jeff Bretz,Democratic,Ohio Senate,2,22965
+Wood,Randy Gardner ,Republican ,Ohio Senate,2,37110
+Butler,Bill Coley ,Republican ,Ohio Senate,4,104591
+Montgomery,Peggy Lehner,Republican,Ohio Senate,6,106095
+Montgomery,Rick McKiddy ,Democratic ,Ohio Senate,6,63874
+Hamilton,Richard Luken,Democratic,Ohio Senate,8,65744
+Hamilton,William Seitz ,Republican ,Ohio Senate,8,104852
+Clark,Jeff Robertson,Democratic,Ohio Senate,10,26905
+Clark,Chris Widener ,Republican ,Ohio Senate,10,34301
+Greene,Jeff Robertson,Democratic,Ohio Senate,10,28079
+Greene,Chris Widener ,Republican ,Ohio Senate,10,49942
+Madison,Jeff Robertson,Democratic,Ohio Senate,10,5215
+Madison,Chris Widener ,Republican ,Ohio Senate,10,11212
+Allen,Keith Faber,Republican,Ohio Senate,12,31917
+Allen,Paul Hinds ,Libertarian ,Ohio Senate,12,10420
+Auglaize,Keith Faber,Republican,Ohio Senate,12,9727
+Auglaize,Paul Hinds ,Libertarian ,Ohio Senate,12,1878
+Champaign,Keith Faber,Republican,Ohio Senate,12,11395
+Champaign,Paul Hinds ,Libertarian ,Ohio Senate,12,4225
+Darke,Keith Faber,Republican,Ohio Senate,12,12111
+Darke,Paul Hinds ,Libertarian ,Ohio Senate,12,2328
+Logan,Keith Faber,Republican,Ohio Senate,12,12227
+Logan,Paul Hinds ,Libertarian ,Ohio Senate,12,3781
+Mercer,Keith Faber,Republican,Ohio Senate,12,17317
+Mercer,Paul Hinds ,Libertarian ,Ohio Senate,12,2869
+Shelby,Keith Faber,Republican,Ohio Senate,12,17000
+Shelby,Paul Hinds ,Libertarian ,Ohio Senate,12,4473
+Adams,Joe Uecker ,Republican ,Ohio Senate,14,6778
+Brown,Joe Uecker ,Republican ,Ohio Senate,14,13415
+Clermont,Joe Uecker ,Republican ,Ohio Senate,14,68784
+Lawrence,Joe Uecker ,Republican ,Ohio Senate,14,3546
+Scioto,Joe Uecker ,Republican ,Ohio Senate,14,17586
+Franklin,Jim Hughes ,Republican ,Ohio Senate,16,129136
+Clinton,Bob Peterson ,Republican ,Ohio Senate,17,13227
+Fayette,Bob Peterson ,Republican ,Ohio Senate,17,8175
+Gallia,Bob Peterson ,Republican ,Ohio Senate,17,7419
+Highland,Bob Peterson ,Republican ,Ohio Senate,17,11775
+Jackson,Bob Peterson ,Republican ,Ohio Senate,17,7722
+Lawrence,Bob Peterson ,Republican ,Ohio Senate,17,12872
+Pickaway,Bob Peterson ,Republican ,Ohio Senate,17,5861
+Pike,Bob Peterson ,Republican ,Ohio Senate,17,5878
+Ross,Bob Peterson ,Republican ,Ohio Senate,17,18809
+Vinton,Bob Peterson ,Republican ,Ohio Senate,17,2097
+Geauga,John Eklund,Republican,Ohio Senate,18, 	23633 
+Geauga,Jim Mueller,Democratic,Ohio Senate,18, 	14123 
+Lake,John Eklund,Republican,Ohio Senate,18, 	33967 
+Lake,Jim Mueller,Democratic,Ohio Senate,18, 	25030 
+Portage,John Eklund,Republican,Ohio Senate,18, 	33362 
+Portage,Jim Mueller,Democratic,Ohio Senate,18, 	36201 
+Athens,Troy Balderson,Republican,Ohio Senate,20,314
+Athens,Teresa Scarmack ,Democratic ,Ohio Senate,20,1339
+Fairfield,Troy Balderson,Republican,Ohio Senate,20,38309
+Fairfield,Teresa Scarmack ,Democratic ,Ohio Senate,20,27640
+Guernsey,Troy Balderson,Republican,Ohio Senate,20,8865
+Guernsey,Teresa Scarmack ,Democratic ,Ohio Senate,20,6620
+Hocking,Troy Balderson,Republican,Ohio Senate,20,5404
+Hocking,Teresa Scarmack ,Democratic ,Ohio Senate,20,6388
+Morgan,Troy Balderson,Republican,Ohio Senate,20,3622
+Morgan,Teresa Scarmack ,Democratic ,Ohio Senate,20,2166
+Muskingum,Troy Balderson,Republican,Ohio Senate,20,25097
+Muskingum,Teresa Scarmack ,Democratic ,Ohio Senate,20,11223
+Pickaway,Troy Balderson,Republican,Ohio Senate,20,8048
+Pickaway,Teresa Scarmack ,Democratic ,Ohio Senate,20,5701
+Ashland,Larry Obhof,Republican,Ohio Senate,22,14818
+Ashland,James Riley ,Democratic ,Ohio Senate,22,7675
+Holmes,Larry Obhof,Republican,Ohio Senate,22,2846
+Holmes,James Riley ,Democratic ,Ohio Senate,22,1317
+Medina,Larry Obhof,Republican,Ohio Senate,22,46416
+Medina,James Riley ,Democratic ,Ohio Senate,22,34085
+Richland,Larry Obhof,Republican,Ohio Senate,22,30445
+Richland,James Riley ,Democratic ,Ohio Senate,22,21623
+Cuyahoga,Jennifer Brady,Democratic,Ohio Senate,24,72594
+Cuyahoga,Thomas Patton ,Republican ,Ohio Senate,24,104252
+Crawford,Tanyce Addison,Democratic,Ohio Senate,26,6860
+Crawford,Dave Burke ,Republican ,Ohio Senate,26,11464
+Marion,Tanyce Addison,Democratic,Ohio Senate,26,12143
+Marion,Dave Burke ,Republican ,Ohio Senate,26,13560
+Morrow,Tanyce Addison,Democratic,Ohio Senate,26,5339
+Morrow,Dave Burke ,Republican ,Ohio Senate,26,9678
+Sandusky,Tanyce Addison,Democratic,Ohio Senate,26,12212
+Sandusky,Dave Burke ,Republican ,Ohio Senate,26,14205
+Seneca,Tanyce Addison,Democratic,Ohio Senate,26,10048
+Seneca,Dave Burke ,Republican ,Ohio Senate,26,13287
+Union,Tanyce Addison,Democratic,Ohio Senate,26,6144
+Union,Dave Burke ,Republican ,Ohio Senate,26,18083
+Wyandot,Tanyce Addison,Democratic,Ohio Senate,26,3995
+Wyandot,Dave Burke ,Republican ,Ohio Senate,26,5778
+Summit,Robert Roush,Republican,Ohio Senate,28,40952
+Summit,Thomas Sawyer ,Democratic ,Ohio Senate,28,104697
+Athens,Lou Gentile,Democratic,Ohio Senate,30,15604
+Athens,Shane Thompson ,Republican ,Ohio Senate,30,8010
+Belmont,Lou Gentile,Democratic,Ohio Senate,30,16714
+Belmont,Shane Thompson ,Republican ,Ohio Senate,30,14088
+Carroll,Lou Gentile,Democratic,Ohio Senate,30,5550
+Carroll,Shane Thompson ,Republican ,Ohio Senate,30,6805
+Harrison,Lou Gentile,Democratic,Ohio Senate,30,3624
+Harrison,Shane Thompson ,Republican ,Ohio Senate,30,3338
+Jefferson,Lou Gentile,Democratic,Ohio Senate,30,19277
+Jefferson,Shane Thompson ,Republican ,Ohio Senate,30,13000
+Meigs,Lou Gentile,Democratic,Ohio Senate,30,3865
+Meigs,Shane Thompson ,Republican ,Ohio Senate,30,5535
+Monroe,Lou Gentile,Democratic,Ohio Senate,30,3616
+Monroe,Shane Thompson ,Republican ,Ohio Senate,30,2907
+Noble,Lou Gentile,Democratic,Ohio Senate,30,2229
+Noble,Shane Thompson ,Republican ,Ohio Senate,30,3306
+Vinton,Lou Gentile,Democratic,Ohio Senate,30,931
+Vinton,Shane Thompson ,Republican ,Ohio Senate,30,975
+Washington,Lou Gentile,Democratic,Ohio Senate,30,10993
+Washington,Shane Thompson ,Republican ,Ohio Senate,30,16920
+Ashtabula,Capri Cafaro,Democratic,Ohio Senate,32,25781
+Ashtabula,Nancy McArthur ,Republican ,Ohio Senate,32,15891
+Geauga,Capri Cafaro,Democratic,Ohio Senate,32,3741
+Geauga,Nancy McArthur ,Republican ,Ohio Senate,32,5690
+Trumbull,Capri Cafaro,Democratic,Ohio Senate,32,69977
+Trumbull,Nancy McArthur ,Republican ,Ohio Senate,32,27100

--- a/2012/20121106__oh__general__state_senate.csv
+++ b/2012/20121106__oh__general__state_senate.csv
@@ -1,66 +1,66 @@
 county,candidate,party,office,district,votes
-Auglaize,Cliff Hite ,Republican ,Ohio Senate,1,7797
-Defiance,Cliff Hite ,Republican ,Ohio Senate,1,11435
-Fulton,Cliff Hite ,Republican ,Ohio Senate,1,4238
-Hancock,Cliff Hite ,Republican ,Ohio Senate,1,25588
-Hardin,Cliff Hite ,Republican ,Ohio Senate,1,8556
-Henry,Cliff Hite ,Republican ,Ohio Senate,1,9011
-Logan,Cliff Hite ,Republican ,Ohio Senate,1,2164
-Paulding,Cliff Hite ,Republican ,Ohio Senate,1,5643
-Putnam,Cliff Hite ,Republican ,Ohio Senate,1,12516
-Van Wert,Cliff Hite ,Republican ,Ohio Senate,1,8688
-Williams,Cliff Hite ,Republican ,Ohio Senate,1,11836
+Auglaize,Cliff Hite,Republican,Ohio Senate,1,7797
+Defiance,Cliff Hite,Republican,Ohio Senate,1,11435
+Fulton,Cliff Hite,Republican,Ohio Senate,1,4238
+Hancock,Cliff Hite,Republican,Ohio Senate,1,25588
+Hardin,Cliff Hite,Republican,Ohio Senate,1,8556
+Henry,Cliff Hite,Republican,Ohio Senate,1,9011
+Logan,Cliff Hite,Republican,Ohio Senate,1,2164
+Paulding,Cliff Hite,Republican,Ohio Senate,1,5643
+Putnam,Cliff Hite,Republican,Ohio Senate,1,12516
+Van Wert,Cliff Hite,Republican,Ohio Senate,1,8688
+Williams,Cliff Hite,Republican,Ohio Senate,1,11836
 Erie,Jeff Bretz,Democratic,Ohio Senate,2,18595
-Erie,Randy Gardner ,Republican ,Ohio Senate,2,17830
+Erie,Randy Gardner,Republican,Ohio Senate,2,17830
 Fulton,Jeff Bretz,Democratic,Ohio Senate,2,4309
-Fulton,Randy Gardner ,Republican ,Ohio Senate,2,8397
+Fulton,Randy Gardner,Republican,Ohio Senate,2,8397
 Lucas,Jeff Bretz,Democratic,Ohio Senate,2,17826
-Lucas,Randy Gardner ,Republican ,Ohio Senate,2,27175
+Lucas,Randy Gardner,Republican,Ohio Senate,2,27175
 Ottawa,Jeff Bretz,Democratic,Ohio Senate,2,9418
-Ottawa,Randy Gardner ,Republican ,Ohio Senate,2,11807
+Ottawa,Randy Gardner,Republican,Ohio Senate,2,11807
 Wood,Jeff Bretz,Democratic,Ohio Senate,2,22965
-Wood,Randy Gardner ,Republican ,Ohio Senate,2,37110
-Butler,Bill Coley ,Republican ,Ohio Senate,4,104591
+Wood,Randy Gardner,Republican,Ohio Senate,2,37110
+Butler,Bill Coley,Republican,Ohio Senate,4,104591
 Montgomery,Peggy Lehner,Republican,Ohio Senate,6,106095
-Montgomery,Rick McKiddy ,Democratic ,Ohio Senate,6,63874
+Montgomery,Rick McKiddy,Democratic,Ohio Senate,6,63874
 Hamilton,Richard Luken,Democratic,Ohio Senate,8,65744
-Hamilton,William Seitz ,Republican ,Ohio Senate,8,104852
+Hamilton,William Seitz,Republican,Ohio Senate,8,104852
 Clark,Jeff Robertson,Democratic,Ohio Senate,10,26905
-Clark,Chris Widener ,Republican ,Ohio Senate,10,34301
+Clark,Chris Widener,Republican,Ohio Senate,10,34301
 Greene,Jeff Robertson,Democratic,Ohio Senate,10,28079
-Greene,Chris Widener ,Republican ,Ohio Senate,10,49942
+Greene,Chris Widener,Republican,Ohio Senate,10,49942
 Madison,Jeff Robertson,Democratic,Ohio Senate,10,5215
-Madison,Chris Widener ,Republican ,Ohio Senate,10,11212
+Madison,Chris Widener,Republican,Ohio Senate,10,11212
 Allen,Keith Faber,Republican,Ohio Senate,12,31917
-Allen,Paul Hinds ,Libertarian ,Ohio Senate,12,10420
+Allen,Paul Hinds,Libertarian,Ohio Senate,12,10420
 Auglaize,Keith Faber,Republican,Ohio Senate,12,9727
-Auglaize,Paul Hinds ,Libertarian ,Ohio Senate,12,1878
+Auglaize,Paul Hinds,Libertarian,Ohio Senate,12,1878
 Champaign,Keith Faber,Republican,Ohio Senate,12,11395
-Champaign,Paul Hinds ,Libertarian ,Ohio Senate,12,4225
+Champaign,Paul Hinds,Libertarian,Ohio Senate,12,4225
 Darke,Keith Faber,Republican,Ohio Senate,12,12111
-Darke,Paul Hinds ,Libertarian ,Ohio Senate,12,2328
+Darke,Paul Hinds,Libertarian,Ohio Senate,12,2328
 Logan,Keith Faber,Republican,Ohio Senate,12,12227
-Logan,Paul Hinds ,Libertarian ,Ohio Senate,12,3781
+Logan,Paul Hinds,Libertarian,Ohio Senate,12,3781
 Mercer,Keith Faber,Republican,Ohio Senate,12,17317
-Mercer,Paul Hinds ,Libertarian ,Ohio Senate,12,2869
+Mercer,Paul Hinds,Libertarian,Ohio Senate,12,2869
 Shelby,Keith Faber,Republican,Ohio Senate,12,17000
-Shelby,Paul Hinds ,Libertarian ,Ohio Senate,12,4473
-Adams,Joe Uecker ,Republican ,Ohio Senate,14,6778
-Brown,Joe Uecker ,Republican ,Ohio Senate,14,13415
-Clermont,Joe Uecker ,Republican ,Ohio Senate,14,68784
-Lawrence,Joe Uecker ,Republican ,Ohio Senate,14,3546
-Scioto,Joe Uecker ,Republican ,Ohio Senate,14,17586
-Franklin,Jim Hughes ,Republican ,Ohio Senate,16,129136
-Clinton,Bob Peterson ,Republican ,Ohio Senate,17,13227
-Fayette,Bob Peterson ,Republican ,Ohio Senate,17,8175
-Gallia,Bob Peterson ,Republican ,Ohio Senate,17,7419
-Highland,Bob Peterson ,Republican ,Ohio Senate,17,11775
-Jackson,Bob Peterson ,Republican ,Ohio Senate,17,7722
-Lawrence,Bob Peterson ,Republican ,Ohio Senate,17,12872
-Pickaway,Bob Peterson ,Republican ,Ohio Senate,17,5861
-Pike,Bob Peterson ,Republican ,Ohio Senate,17,5878
-Ross,Bob Peterson ,Republican ,Ohio Senate,17,18809
-Vinton,Bob Peterson ,Republican ,Ohio Senate,17,2097
+Shelby,Paul Hinds,Libertarian,Ohio Senate,12,4473
+Adams,Joe Uecker,Republican,Ohio Senate,14,6778
+Brown,Joe Uecker,Republican,Ohio Senate,14,13415
+Clermont,Joe Uecker,Republican,Ohio Senate,14,68784
+Lawrence,Joe Uecker,Republican,Ohio Senate,14,3546
+Scioto,Joe Uecker,Republican,Ohio Senate,14,17586
+Franklin,Jim Hughes,Republican,Ohio Senate,16,129136
+Clinton,Bob Peterson,Republican,Ohio Senate,17,13227
+Fayette,Bob Peterson,Republican,Ohio Senate,17,8175
+Gallia,Bob Peterson,Republican,Ohio Senate,17,7419
+Highland,Bob Peterson,Republican,Ohio Senate,17,11775
+Jackson,Bob Peterson,Republican,Ohio Senate,17,7722
+Lawrence,Bob Peterson,Republican,Ohio Senate,17,12872
+Pickaway,Bob Peterson,Republican,Ohio Senate,17,5861
+Pike,Bob Peterson,Republican,Ohio Senate,17,5878
+Ross,Bob Peterson,Republican,Ohio Senate,17,18809
+Vinton,Bob Peterson,Republican,Ohio Senate,17,2097
 Geauga,John Eklund,Republican,Ohio Senate,18, 	23633 
 Geauga,Jim Mueller,Democratic,Ohio Senate,18, 	14123 
 Lake,John Eklund,Republican,Ohio Senate,18, 	33967 
@@ -68,68 +68,68 @@ Lake,Jim Mueller,Democratic,Ohio Senate,18, 	25030
 Portage,John Eklund,Republican,Ohio Senate,18, 	33362 
 Portage,Jim Mueller,Democratic,Ohio Senate,18, 	36201 
 Athens,Troy Balderson,Republican,Ohio Senate,20,314
-Athens,Teresa Scarmack ,Democratic ,Ohio Senate,20,1339
+Athens,Teresa Scarmack,Democratic,Ohio Senate,20,1339
 Fairfield,Troy Balderson,Republican,Ohio Senate,20,38309
-Fairfield,Teresa Scarmack ,Democratic ,Ohio Senate,20,27640
+Fairfield,Teresa Scarmack,Democratic,Ohio Senate,20,27640
 Guernsey,Troy Balderson,Republican,Ohio Senate,20,8865
-Guernsey,Teresa Scarmack ,Democratic ,Ohio Senate,20,6620
+Guernsey,Teresa Scarmack,Democratic,Ohio Senate,20,6620
 Hocking,Troy Balderson,Republican,Ohio Senate,20,5404
-Hocking,Teresa Scarmack ,Democratic ,Ohio Senate,20,6388
+Hocking,Teresa Scarmack,Democratic,Ohio Senate,20,6388
 Morgan,Troy Balderson,Republican,Ohio Senate,20,3622
-Morgan,Teresa Scarmack ,Democratic ,Ohio Senate,20,2166
+Morgan,Teresa Scarmack,Democratic,Ohio Senate,20,2166
 Muskingum,Troy Balderson,Republican,Ohio Senate,20,25097
-Muskingum,Teresa Scarmack ,Democratic ,Ohio Senate,20,11223
+Muskingum,Teresa Scarmack,Democratic,Ohio Senate,20,11223
 Pickaway,Troy Balderson,Republican,Ohio Senate,20,8048
-Pickaway,Teresa Scarmack ,Democratic ,Ohio Senate,20,5701
+Pickaway,Teresa Scarmack,Democratic,Ohio Senate,20,5701
 Ashland,Larry Obhof,Republican,Ohio Senate,22,14818
-Ashland,James Riley ,Democratic ,Ohio Senate,22,7675
+Ashland,James Riley,Democratic,Ohio Senate,22,7675
 Holmes,Larry Obhof,Republican,Ohio Senate,22,2846
-Holmes,James Riley ,Democratic ,Ohio Senate,22,1317
+Holmes,James Riley,Democratic,Ohio Senate,22,1317
 Medina,Larry Obhof,Republican,Ohio Senate,22,46416
-Medina,James Riley ,Democratic ,Ohio Senate,22,34085
+Medina,James Riley,Democratic,Ohio Senate,22,34085
 Richland,Larry Obhof,Republican,Ohio Senate,22,30445
-Richland,James Riley ,Democratic ,Ohio Senate,22,21623
+Richland,James Riley,Democratic,Ohio Senate,22,21623
 Cuyahoga,Jennifer Brady,Democratic,Ohio Senate,24,72594
-Cuyahoga,Thomas Patton ,Republican ,Ohio Senate,24,104252
+Cuyahoga,Thomas Patton,Republican,Ohio Senate,24,104252
 Crawford,Tanyce Addison,Democratic,Ohio Senate,26,6860
-Crawford,Dave Burke ,Republican ,Ohio Senate,26,11464
+Crawford,Dave Burke,Republican,Ohio Senate,26,11464
 Marion,Tanyce Addison,Democratic,Ohio Senate,26,12143
-Marion,Dave Burke ,Republican ,Ohio Senate,26,13560
+Marion,Dave Burke,Republican,Ohio Senate,26,13560
 Morrow,Tanyce Addison,Democratic,Ohio Senate,26,5339
-Morrow,Dave Burke ,Republican ,Ohio Senate,26,9678
+Morrow,Dave Burke,Republican,Ohio Senate,26,9678
 Sandusky,Tanyce Addison,Democratic,Ohio Senate,26,12212
-Sandusky,Dave Burke ,Republican ,Ohio Senate,26,14205
+Sandusky,Dave Burke,Republican,Ohio Senate,26,14205
 Seneca,Tanyce Addison,Democratic,Ohio Senate,26,10048
-Seneca,Dave Burke ,Republican ,Ohio Senate,26,13287
+Seneca,Dave Burke,Republican,Ohio Senate,26,13287
 Union,Tanyce Addison,Democratic,Ohio Senate,26,6144
-Union,Dave Burke ,Republican ,Ohio Senate,26,18083
+Union,Dave Burke,Republican,Ohio Senate,26,18083
 Wyandot,Tanyce Addison,Democratic,Ohio Senate,26,3995
-Wyandot,Dave Burke ,Republican ,Ohio Senate,26,5778
+Wyandot,Dave Burke,Republican,Ohio Senate,26,5778
 Summit,Robert Roush,Republican,Ohio Senate,28,40952
-Summit,Thomas Sawyer ,Democratic ,Ohio Senate,28,104697
+Summit,Thomas Sawyer,Democratic,Ohio Senate,28,104697
 Athens,Lou Gentile,Democratic,Ohio Senate,30,15604
-Athens,Shane Thompson ,Republican ,Ohio Senate,30,8010
+Athens,Shane Thompson,Republican,Ohio Senate,30,8010
 Belmont,Lou Gentile,Democratic,Ohio Senate,30,16714
-Belmont,Shane Thompson ,Republican ,Ohio Senate,30,14088
+Belmont,Shane Thompson,Republican,Ohio Senate,30,14088
 Carroll,Lou Gentile,Democratic,Ohio Senate,30,5550
-Carroll,Shane Thompson ,Republican ,Ohio Senate,30,6805
+Carroll,Shane Thompson,Republican,Ohio Senate,30,6805
 Harrison,Lou Gentile,Democratic,Ohio Senate,30,3624
-Harrison,Shane Thompson ,Republican ,Ohio Senate,30,3338
+Harrison,Shane Thompson,Republican,Ohio Senate,30,3338
 Jefferson,Lou Gentile,Democratic,Ohio Senate,30,19277
-Jefferson,Shane Thompson ,Republican ,Ohio Senate,30,13000
+Jefferson,Shane Thompson,Republican,Ohio Senate,30,13000
 Meigs,Lou Gentile,Democratic,Ohio Senate,30,3865
-Meigs,Shane Thompson ,Republican ,Ohio Senate,30,5535
+Meigs,Shane Thompson,Republican,Ohio Senate,30,5535
 Monroe,Lou Gentile,Democratic,Ohio Senate,30,3616
-Monroe,Shane Thompson ,Republican ,Ohio Senate,30,2907
+Monroe,Shane Thompson,Republican,Ohio Senate,30,2907
 Noble,Lou Gentile,Democratic,Ohio Senate,30,2229
-Noble,Shane Thompson ,Republican ,Ohio Senate,30,3306
+Noble,Shane Thompson,Republican,Ohio Senate,30,3306
 Vinton,Lou Gentile,Democratic,Ohio Senate,30,931
-Vinton,Shane Thompson ,Republican ,Ohio Senate,30,975
+Vinton,Shane Thompson,Republican,Ohio Senate,30,975
 Washington,Lou Gentile,Democratic,Ohio Senate,30,10993
-Washington,Shane Thompson ,Republican ,Ohio Senate,30,16920
+Washington,Shane Thompson,Republican,Ohio Senate,30,16920
 Ashtabula,Capri Cafaro,Democratic,Ohio Senate,32,25781
-Ashtabula,Nancy McArthur ,Republican ,Ohio Senate,32,15891
+Ashtabula,Nancy McArthur,Republican,Ohio Senate,32,15891
 Geauga,Capri Cafaro,Democratic,Ohio Senate,32,3741
-Geauga,Nancy McArthur ,Republican ,Ohio Senate,32,5690
+Geauga,Nancy McArthur,Republican,Ohio Senate,32,5690
 Trumbull,Capri Cafaro,Democratic,Ohio Senate,32,69977
-Trumbull,Nancy McArthur ,Republican ,Ohio Senate,32,27100
+Trumbull,Nancy McArthur,Republican,Ohio Senate,32,27100


### PR DESCRIPTION
This is Ohio state senate general election data from 2012.

Source data from [here](http://www.sos.state.oh.us/SOS/elections/Research/electResultsMain/2012Results.aspx).